### PR TITLE
feat: avoid themes folder to be included while building next app

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "hooks/LanguageHook/multilingual-hook.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "themes"]
 }


### PR DESCRIPTION
Previously, we need to delete themes folder while building our next app and include it again after building successfully. To avoid this pain I've included "themes" folder in tsconfig.json file. This will include themes folder while building next app.