### PR TITLE
build: fix irrelevant import err

### DIFF
--- a/store/slices/auth/token-login-slice.ts
+++ b/store/slices/auth/token-login-slice.ts
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../../root-reducer';
 import getTokenLoginApi from '../../../services/api/auth/get-token-from-login-api';
-import { showToast } from '../../../components/ToastNotificationNew';
-// import { UpdatePartyName } from '../general_slices/profile-page-slice';
 
 export const getAccessToken: any = createAsyncThunk('accessToken/getAccessToken', async (param: any, { dispatch }) => {
   const AccessTokenData = await getTokenLoginApi(param);
@@ -35,7 +33,6 @@ export const GetAccessTokenScreen = createSlice({
   initialState,
   reducers: {
     storeToken(state: any, action: any) {
-      console.log('token in slice', action?.payload);
       state.token = action?.payload?.access_token;
       state.error = '';
       state.isLoading = 'succeeded';


### PR DESCRIPTION
while building giving this error 

`./store/slices/auth/token-login-slice.ts:4:10
Type error: Module '"../../../components/ToastNotificationNew"' has no exported member 'showToast'.

  2 | import { RootState } from '../../root-reducer';
  3 | import getTokenLoginApi from '../../../services/api/auth/get-token-from-login-api';
> 4 | import { showToast } from '../../../components/ToastNotificationNew';
    |          ^
  5 | // import { UpdatePartyName } from '../general_slices/profile-page-slice';
  6 |
  7 | export const getAccessToken: any = createAsyncThunk('accessToken/getAccessToken', async (param: any, { dispatch }) => {
`