### PR TITLE
bug fixed in the fetch tags hook file

### DIFF
--- a/hooks/HomePageHooks/useFeaturedCollections.ts
+++ b/hooks/HomePageHooks/useFeaturedCollections.ts
@@ -29,6 +29,7 @@ const useFeaturedCollections = () => {
                 tag_name: data.tag_name,
                 description: data.description,
                 value: data?.value?.message?.data,
+                tag_image: data?.tag_image,
               };
             } else {
               setErrMessage(data?.value?.message?.error);

--- a/services/api/home-page-apis/home-display-tag-api.ts
+++ b/services/api/home-page-apis/home-display-tag-api.ts
@@ -17,7 +17,7 @@ const getDisplaytagsDataFromAPI = async (appConfig: APP_CONFIG, reqParams: any, 
 
           const res = await executeGETAPI(appConfig, 'display-tags-api', token, additionalParams);
 
-          return { tag_name: tag.name, description: tag.description, value: res?.data };
+          return { tag_name: tag.name, description: tag.description, value: res?.data, tag_image: tag.tag_image };
         })
     );
 


### PR DESCRIPTION
# Description

Added a tag_image key value pair to the return object of fetchDisplayTagsDataFunction hook as well as to the getDisplaytagsDataFromAPI service api function.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
