### PR TITLE
Add Utility Functions and Hooks for fetching Multi language data on pages and Meta tags

### DIFF
--- a/hooks/GeneralHooks/useInitializeStoreWithMultiLingualData.ts
+++ b/hooks/GeneralHooks/useInitializeStoreWithMultiLingualData.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { multiLanguageDataFromStore, setMultiLingualData } from '../../store/slices/general_slices/multilang-slice';
+import useMultilangHook from '../LanguageHook/Multilanguages-hook';
+
+const useInitializeStoreWithMultiLingualData = (multiLingualData: any) => {
+  const dispatch = useDispatch();
+  const MultiLanguageFromStore = useSelector(multiLanguageDataFromStore);
+  if (MultiLanguageFromStore?.languageData?.length === 0) {
+    dispatch(setMultiLingualData(multiLingualData));
+    useMultilangHook();
+  }
+  return {};
+};
+
+export default useInitializeStoreWithMultiLingualData;

--- a/hooks/LanguageHook/Multilanguages-hook.ts
+++ b/hooks/LanguageHook/Multilanguages-hook.ts
@@ -9,6 +9,17 @@ const useMultilangHook = () => {
   const [multiLanguagesData, SetMultiLanguagesData] = useState<any>([]);
   const [selectedLang, setSelectedLang] = useState<any>('en');
 
+  const handleLanguageChange = (lang: any) => {
+    if (lang === 'ar') {
+      document.documentElement.dir = 'rtl';
+    } else {
+      document.documentElement.dir = 'ltr';
+    }
+    setSelectedLang(lang);
+
+    localStorage.setItem('selectedLanguage', lang);
+  };
+
   useEffect(() => {
     // Retrieve the selected language from localStorage on component mount
     const storedLang = localStorage.getItem('selectedLanguage');
@@ -25,17 +36,6 @@ const useMultilangHook = () => {
       SetMultiLanguagesData(MultiLanguageFromStore?.languageData);
     }
   }, [MultiLanguageFromStore]);
-
-  const handleLanguageChange = (lang: any) => {
-    if (lang === 'ar') {
-      document.documentElement.dir = 'rtl';
-    } else {
-      document.documentElement.dir = 'ltr';
-    }
-    setSelectedLang(lang);
-
-    localStorage.setItem('selectedLanguage', lang);
-  };
 
   useEffect(() => {
     const params = {

--- a/interfaces/meta-data-interface.ts
+++ b/interfaces/meta-data-interface.ts
@@ -4,7 +4,10 @@ export interface PageMetaDataTypes {
   robots: string;
   description: string;
 }
-
-export interface MetaDataTypes {
+interface PageData {
   metaData: PageMetaDataTypes;
+  multiLingualListTranslationTextList: any[];
+}
+export interface ServerDataTypes {
+  serverDataForPages: PageData;
 }

--- a/pages/brand-product/[category-slug]/[productId]/index.tsx
+++ b/pages/brand-product/[category-slug]/[productId]/index.tsx
@@ -3,6 +3,7 @@ import ProductPageMaster from '../../../../components/ProductPageComponents/Prod
 import { MetaDataTypes } from '../../../../interfaces/meta-data-interface';
 import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../../services/config/app-config';
+import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   return (
@@ -23,15 +24,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/brand-product/[category-slug]/[productId]/index.tsx
+++ b/pages/brand-product/[category-slug]/[productId]/index.tsx
@@ -1,11 +1,13 @@
-import PageMetaData from '../../../../components/PageMetaData';
-import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
 import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
-import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
-import { CONSTANTS } from '../../../../services/config/app-config';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
+import { CONSTANTS } from '../../../../services/config/app-config';
+import useInitializeStoreWithMultiLingualData from '../../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
+import PageMetaData from '../../../../components/PageMetaData';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/brand-product/[category-slug]/[productId]/index.tsx
+++ b/pages/brand-product/[category-slug]/[productId]/index.tsx
@@ -1,14 +1,14 @@
 import PageMetaData from '../../../../components/PageMetaData';
 import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
-import { MetaDataTypes } from '../../../../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
 import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <>
         <ProductPageMaster />
       </>

--- a/pages/brand/[category]/index.tsx
+++ b/pages/brand/[category]/index.tsx
@@ -3,6 +3,7 @@ import { CONSTANTS } from '../../../services/config/app-config';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 import PageMetaData from '../../../components/PageMetaData';
 import { MetaDataTypes } from '../../../interfaces/meta-data-interface';
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   return (
@@ -23,15 +24,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/brand/[category]/index.tsx
+++ b/pages/brand/[category]/index.tsx
@@ -2,13 +2,13 @@ import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 import PageMetaData from '../../../components/PageMetaData';
-import { MetaDataTypes } from '../../../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <>
         <ProductListingMaster />
       </>

--- a/pages/brand/[category]/index.tsx
+++ b/pages/brand/[category]/index.tsx
@@ -1,11 +1,12 @@
-import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
-import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
-import PageMetaData from '../../../components/PageMetaData';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
+import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import PageMetaData from '../../../components/PageMetaData';
+import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -3,8 +3,11 @@ import { CONSTANTS } from '../services/config/app-config';
 import CartListing from '../components/Cart/CartListing';
 import MetaTag from '../services/api/general-apis/meta-tag-api';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
-const Cart = () => {
+const Cart = ({ serverDataForPages }: any) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+
   return (
     <>
       <CartListing />

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CONSTANTS } from '../services/config/app-config';
 import CartListing from '../components/Cart/CartListing';
 import MetaTag from '../services/api/general-apis/meta-tag-api';
+import getPageMetaData from '../utils/fetch-page-meta-deta';
 
 const Cart = () => {
   return (
@@ -18,17 +19,8 @@ export async function getServerSideProps(context: any) {
   const entity = 'seo';
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
-
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/catalog-product/[category]/[productId]/index.tsx
+++ b/pages/catalog-product/[category]/[productId]/index.tsx
@@ -1,14 +1,14 @@
 import PageMetaData from '../../../../components/PageMetaData';
 import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
-import { MetaDataTypes } from '../../../../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
 import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <ProductPageMaster />
     </>
   );

--- a/pages/catalog-product/[category]/[productId]/index.tsx
+++ b/pages/catalog-product/[category]/[productId]/index.tsx
@@ -3,6 +3,7 @@ import ProductPageMaster from '../../../../components/ProductPageComponents/Prod
 import { MetaDataTypes } from '../../../../interfaces/meta-data-interface';
 import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../../services/config/app-config';
+import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   return (
@@ -21,15 +22,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/catalog-product/[category]/[productId]/index.tsx
+++ b/pages/catalog-product/[category]/[productId]/index.tsx
@@ -1,11 +1,12 @@
-import PageMetaData from '../../../../components/PageMetaData';
-import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
 import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
-import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import PageMetaData from '../../../../components/PageMetaData';
+import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/catalog/[category]/index.tsx
+++ b/pages/catalog/[category]/index.tsx
@@ -3,6 +3,7 @@ import ProductListingMaster from '../../../components/ProductCategoriesComponent
 import { MetaDataTypes } from '../../../interfaces/meta-data-interface';
 import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   return (
@@ -21,15 +22,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/catalog/[category]/index.tsx
+++ b/pages/catalog/[category]/index.tsx
@@ -1,11 +1,12 @@
+import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import { CONSTANTS } from '../../../services/config/app-config';
+import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../../../components/PageMetaData';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
-import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
-import MetaTag from '../../../services/api/general-apis/meta-tag-api';
-import { CONSTANTS } from '../../../services/config/app-config';
-import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/catalog/[category]/index.tsx
+++ b/pages/catalog/[category]/index.tsx
@@ -1,14 +1,14 @@
 import PageMetaData from '../../../components/PageMetaData';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
-import { MetaDataTypes } from '../../../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <ProductListingMaster />
     </>
   );

--- a/pages/catalog/index.tsx
+++ b/pages/catalog/index.tsx
@@ -1,14 +1,13 @@
-import CatalogList from '../../components/Catalog/CatalogList';
-import PageMetaData from '../../components/PageMetaData';
-import { MetaDataTypes } from '../../interfaces/meta-data-interface';
-import MetaTag from '../../services/api/general-apis/meta-tag-api';
+import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import { CONSTANTS } from '../../services/config/app-config';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import PageMetaData from '../../components/PageMetaData';
+import CatalogList from '../../components/Catalog/CatalogList';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <CatalogList />
     </>
   );

--- a/pages/catalog/index.tsx
+++ b/pages/catalog/index.tsx
@@ -1,10 +1,13 @@
 import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import { CONSTANTS } from '../../services/config/app-config';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../../components/PageMetaData';
 import CatalogList from '../../components/Catalog/CatalogList';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/catalog/index.tsx
+++ b/pages/catalog/index.tsx
@@ -3,6 +3,7 @@ import PageMetaData from '../../components/PageMetaData';
 import { MetaDataTypes } from '../../interfaces/meta-data-interface';
 import MetaTag from '../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../services/config/app-config';
+import getPageMetaData from '../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   return (
@@ -21,15 +22,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -3,6 +3,7 @@ import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { MetaDataTypes } from '../interfaces/meta-data-interface';
 import CheckoutPageMaster from '../components/CheckoutPageComponents/CheckoutPageMaster';
 import PageMetaData from '../components/PageMetaData';
+import getPageMetaData from '../utils/fetch-page-meta-deta';
 
 const Checkout = ({ metaData }: MetaDataTypes) => {
   return (
@@ -21,15 +22,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -4,8 +4,10 @@ import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import CheckoutPageMaster from '../components/CheckoutPageComponents/CheckoutPageMaster';
 import PageMetaData from '../components/PageMetaData';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
 const Checkout = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages} />}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,14 +1,14 @@
 import { CONSTANTS } from '../services/config/app-config';
 import MetaTag from '../services/api/general-apis/meta-tag-api';
-import { MetaDataTypes } from '../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import CheckoutPageMaster from '../components/CheckoutPageComponents/CheckoutPageMaster';
 import PageMetaData from '../components/PageMetaData';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 
-const Checkout = ({ metaData }: MetaDataTypes) => {
+const Checkout = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages} />}
       <CheckoutPageMaster />
     </>
   );

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -5,6 +5,7 @@ import LoginComponent from '../components/Auth/LoginComponent';
 import checkAuthorizedUser from '../utils/auth';
 import PageMetaData from '../components/PageMetaData';
 import { MetaDataTypes } from '../interfaces/meta-data-interface';
+import getPageMetaData from '../utils/fetch-page-meta-deta';
 
 const login = ({ metaData }: MetaDataTypes) => {
   const router = useRouter();
@@ -32,15 +33,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,13 +1,15 @@
 import { useRouter } from 'next/router';
 import { CONSTANTS } from '../services/config/app-config';
-import MetaTag from '../services/api/general-apis/meta-tag-api';
 import LoginComponent from '../components/Auth/LoginComponent';
 import checkAuthorizedUser from '../utils/auth';
 import PageMetaData from '../components/PageMetaData';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
 const login = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+
   const router = useRouter();
   function checkIfUserIsAuthorized() {
     const checkUserStatus = checkAuthorizedUser();

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/router';
 import { CONSTANTS } from '../services/config/app-config';
-import LoginComponent from '../components/Auth/LoginComponent';
 import checkAuthorizedUser from '../utils/auth';
-import PageMetaData from '../components/PageMetaData';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import PageMetaData from '../components/PageMetaData';
+import LoginComponent from '../components/Auth/LoginComponent';
 
 const login = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -4,10 +4,10 @@ import MetaTag from '../services/api/general-apis/meta-tag-api';
 import LoginComponent from '../components/Auth/LoginComponent';
 import checkAuthorizedUser from '../utils/auth';
 import PageMetaData from '../components/PageMetaData';
-import { MetaDataTypes } from '../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 
-const login = ({ metaData }: MetaDataTypes) => {
+const login = ({ serverDataForPages }: ServerDataTypes) => {
   const router = useRouter();
   function checkIfUserIsAuthorized() {
     const checkUserStatus = checkAuthorizedUser();
@@ -19,7 +19,7 @@ const login = ({ metaData }: MetaDataTypes) => {
   }
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       {CONSTANTS?.ALLOW_GUEST_TO_ACCESS_SITE_EVEN_WITHOUT_AUTHENTICATION ? <LoginComponent /> : checkIfUserIsAuthorized()}
     </>
   );

--- a/pages/my-orders/index.tsx
+++ b/pages/my-orders/index.tsx
@@ -1,7 +1,6 @@
-import OrderMaster from '../../components/MyOrder/OrderMaster';
-import MetaTag from '../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../services/config/app-config';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import OrderMaster from '../../components/MyOrder/OrderMaster';
 
 const MyOrder = () => {
   return (

--- a/pages/my-orders/index.tsx
+++ b/pages/my-orders/index.tsx
@@ -1,6 +1,7 @@
 import OrderMaster from '../../components/MyOrder/OrderMaster';
 import MetaTag from '../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../services/config/app-config';
+import getPageMetaData from '../../utils/fetch-page-meta-deta';
 
 const MyOrder = () => {
   return (
@@ -19,16 +20,11 @@ export async function getServerSideProps(context: any) {
   const url = `${context.resolvedUrl.split('?')[0]}`;
 
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let meta_data: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-
-    if (meta_data !== null && Object.keys(meta_data).length > 0) {
-      const metaData = meta_data?.data?.message?.data;
-      return { props: { metaData } };
-    } else {
-      return { props: {} };
-    }
+    return await getPageMetaData(params, url);
   } else {
-    return { props: {} };
+    return {
+      props: {},
+    };
   }
 }
 

--- a/pages/order-history/[orderStatus]/index.tsx
+++ b/pages/order-history/[orderStatus]/index.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-import OrderListMaster from '../../../components/OrderListComponents/OrderListMaster';
 import { CONSTANTS } from '../../../services/config/app-config';
-import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import OrderListMaster from '../../../components/OrderListComponents/OrderListMaster';
 
 const Index = () => {
   return <OrderListMaster />;

--- a/pages/order-history/[orderStatus]/index.tsx
+++ b/pages/order-history/[orderStatus]/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import OrderListMaster from '../../../components/OrderListComponents/OrderListMaster';
 import { CONSTANTS } from '../../../services/config/app-config';
 import MetaTag from '../../../services/api/general-apis/meta-tag-api';
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = () => {
   return <OrderListMaster />;
@@ -14,17 +15,12 @@ export async function getServerSideProps(context: any) {
   const entity = 'seo';
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
-
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let meta_data: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (meta_data !== null && Object.keys(meta_data).length > 0) {
-      const metaData = meta_data?.data?.message?.data;
-      return { props: { metaData } };
-    } else {
-      return { props: {} };
-    }
+    return await getPageMetaData(params, url);
   } else {
-    return { props: {} };
+    return {
+      props: {},
+    };
   }
 }
 

--- a/pages/order-history/index.tsx
+++ b/pages/order-history/index.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
 import { CONSTANTS } from '../../services/config/app-config';
-import MetaTag from '../../services/api/general-apis/meta-tag-api';
-import OrderListMaster from '../../components/OrderListComponents/OrderListMaster';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import OrderListMaster from '../../components/OrderListComponents/OrderListMaster';
 
 const Index = () => {
   return <OrderListMaster />;

--- a/pages/order-history/index.tsx
+++ b/pages/order-history/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CONSTANTS } from '../../services/config/app-config';
 import MetaTag from '../../services/api/general-apis/meta-tag-api';
 import OrderListMaster from '../../components/OrderListComponents/OrderListMaster';
+import getPageMetaData from '../../utils/fetch-page-meta-deta';
 
 const Index = () => {
   return <OrderListMaster />;
@@ -14,17 +15,12 @@ export async function getServerSideProps(context: any) {
   const entity = 'seo';
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
-
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let meta_data: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (meta_data !== null && Object.keys(meta_data).length > 0) {
-      const metaData = meta_data?.data?.message?.data;
-      return { props: { metaData } };
-    } else {
-      return { props: {} };
-    }
+    return await getPageMetaData(params, url);
   } else {
-    return { props: {} };
+    return {
+      props: {},
+    };
   }
 }
 

--- a/pages/product-category/[category]/index.tsx
+++ b/pages/product-category/[category]/index.tsx
@@ -5,6 +5,7 @@ import useGoogleAnalyticsOperationsHandler from '../../../hooks/GoogleAnalytics/
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 import PageMetaData from '../../../components/PageMetaData';
 import { MetaDataTypes } from '../../../interfaces/meta-data-interface';
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
@@ -29,15 +30,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/product-category/[category]/index.tsx
+++ b/pages/product-category/[category]/index.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from 'react';
-import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
-import useGoogleAnalyticsOperationsHandler from '../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
-import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
-import PageMetaData from '../../../components/PageMetaData';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import useGoogleAnalyticsOperationsHandler from '../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
+import PageMetaData from '../../../components/PageMetaData';
+import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);

--- a/pages/product-category/[category]/index.tsx
+++ b/pages/product-category/[category]/index.tsx
@@ -4,17 +4,17 @@ import { CONSTANTS } from '../../../services/config/app-config';
 import useGoogleAnalyticsOperationsHandler from '../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 import PageMetaData from '../../../components/PageMetaData';
-import { MetaDataTypes } from '../../../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Listing Page');
   }, []);
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <>
         <ProductListingMaster />
       </>

--- a/pages/product-category/[category]/index.tsx
+++ b/pages/product-category/[category]/index.tsx
@@ -6,8 +6,10 @@ import ProductListingMaster from '../../../components/ProductCategoriesComponent
 import PageMetaData from '../../../components/PageMetaData';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Listing Page');

--- a/pages/product-category/index.tsx
+++ b/pages/product-category/index.tsx
@@ -6,8 +6,10 @@ import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import { useEffect } from 'react';
 import useGoogleAnalyticsOperationsHandler from '../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Listing Page');

--- a/pages/product-category/index.tsx
+++ b/pages/product-category/index.tsx
@@ -2,19 +2,19 @@ import MetaTag from '../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../services/config/app-config';
 import ProductListingMaster from '../../components/ProductCategoriesComponents/ProductListingMaster';
 import PageMetaData from '../../components/PageMetaData';
-import { MetaDataTypes } from '../../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import { useEffect } from 'react';
 import useGoogleAnalyticsOperationsHandler from '../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Listing Page');
   }, []);
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <>
         <ProductListingMaster />
       </>

--- a/pages/product-category/index.tsx
+++ b/pages/product-category/index.tsx
@@ -1,12 +1,11 @@
-import MetaTag from '../../services/api/general-apis/meta-tag-api';
-import { CONSTANTS } from '../../services/config/app-config';
-import ProductListingMaster from '../../components/ProductCategoriesComponents/ProductListingMaster';
-import PageMetaData from '../../components/PageMetaData';
-import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import { useEffect } from 'react';
-import useGoogleAnalyticsOperationsHandler from '../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
+import { CONSTANTS } from '../../services/config/app-config';
+import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import useGoogleAnalyticsOperationsHandler from '../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import useInitializeStoreWithMultiLingualData from '../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import PageMetaData from '../../components/PageMetaData';
+import ProductListingMaster from '../../components/ProductCategoriesComponents/ProductListingMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);

--- a/pages/product-category/index.tsx
+++ b/pages/product-category/index.tsx
@@ -5,6 +5,7 @@ import PageMetaData from '../../components/PageMetaData';
 import { MetaDataTypes } from '../../interfaces/meta-data-interface';
 import { useEffect } from 'react';
 import useGoogleAnalyticsOperationsHandler from '../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
+import getPageMetaData from '../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
@@ -29,15 +30,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/product/[category-slug]/[productId]/index.tsx
+++ b/pages/product/[category-slug]/[productId]/index.tsx
@@ -1,20 +1,21 @@
 import { useEffect } from 'react';
+import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
+import { CONSTANTS } from '../../../../services/config/app-config';
+import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import useGoogleAnalyticsOperationsHandler from '../../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import PageMetaData from '../../../../components/PageMetaData';
 import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
-import { MetaDataTypes } from '../../../../interfaces/meta-data-interface';
-import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
-import { CONSTANTS } from '../../../../services/config/app-config';
-import useGoogleAnalyticsOperationsHandler from '../../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
-import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: MetaDataTypes) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Detail Page');
   }, []);
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <ProductPageMaster />
     </>
   );

--- a/pages/product/[category-slug]/[productId]/index.tsx
+++ b/pages/product/[category-slug]/[productId]/index.tsx
@@ -5,6 +5,7 @@ import { MetaDataTypes } from '../../../../interfaces/meta-data-interface';
 import MetaTag from '../../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import useGoogleAnalyticsOperationsHandler from '../../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
+import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: MetaDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
@@ -27,15 +28,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -4,8 +4,10 @@ import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import PageMetaData from '../components/PageMetaData';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
 const Register = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -3,6 +3,7 @@ import { CONSTANTS } from '../services/config/app-config';
 import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { MetaDataTypes } from '../interfaces/meta-data-interface';
 import PageMetaData from '../components/PageMetaData';
+import getPageMetaData from '../utils/fetch-page-meta-deta';
 
 const Register = ({ metaData }: MetaDataTypes) => {
   return (
@@ -21,15 +22,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
 import { CONSTANTS } from '../services/config/app-config';
-import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
-import PageMetaData from '../components/PageMetaData';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import PageMetaData from '../components/PageMetaData';
 
 const Register = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { CONSTANTS } from '../services/config/app-config';
 import MetaTag from '../services/api/general-apis/meta-tag-api';
-import { MetaDataTypes } from '../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import PageMetaData from '../components/PageMetaData';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 
-const Register = ({ metaData }: MetaDataTypes) => {
+const Register = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <div>Register</div>
     </>
   );

--- a/pages/reports/[order_report]/index.tsx
+++ b/pages/reports/[order_report]/index.tsx
@@ -1,10 +1,9 @@
-import OrderReportMaster from '../../../components/OrderReportComponents/OrderReportMaster';
-import PageMetaData from '../../../components/PageMetaData';
 import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
-import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
-import MetaTag from '../../../services/api/general-apis/meta-tag-api';
-import { CONSTANTS } from '../../../services/config/app-config';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
+import { CONSTANTS } from '../../../services/config/app-config';
+import PageMetaData from '../../../components/PageMetaData';
+import OrderReportMaster from '../../../components/OrderReportComponents/OrderReportMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);

--- a/pages/reports/[order_report]/index.tsx
+++ b/pages/reports/[order_report]/index.tsx
@@ -2,6 +2,7 @@ import OrderReportMaster from '../../../components/OrderReportComponents/OrderRe
 import PageMetaData from '../../../components/PageMetaData';
 import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = ({ metaData }: any) => {
   return (
@@ -22,15 +23,11 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let meta_data: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (meta_data !== null && Object.keys(meta_data).length > 0) {
-      const metaData = meta_data?.data?.message?.data;
-      return { props: { metaData } };
-    } else {
-      return { props: {} };
-    }
+    return await getPageMetaData(params, url);
   } else {
-    return { props: {} };
+    return {
+      props: {},
+    };
   }
 }
 export default Index;

--- a/pages/reports/[order_report]/index.tsx
+++ b/pages/reports/[order_report]/index.tsx
@@ -1,13 +1,14 @@
 import OrderReportMaster from '../../../components/OrderReportComponents/OrderReportMaster';
 import PageMetaData from '../../../components/PageMetaData';
+import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
-const Index = ({ metaData }: any) => {
+const Index = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <>
         <OrderReportMaster />
       </>

--- a/pages/reports/[order_report]/index.tsx
+++ b/pages/reports/[order_report]/index.tsx
@@ -1,11 +1,13 @@
 import OrderReportMaster from '../../../components/OrderReportComponents/OrderReportMaster';
 import PageMetaData from '../../../components/PageMetaData';
+import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import MetaTag from '../../../services/api/general-apis/meta-tag-api';
 import { CONSTANTS } from '../../../services/config/app-config';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -4,6 +4,7 @@ import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { MetaDataTypes } from '../interfaces/meta-data-interface';
 import PageMetaData from '../components/PageMetaData';
 import WishlistMaster from '../components/WishlistComponents/WishListMaster';
+import getPageMetaData from '../utils/fetch-page-meta-deta';
 
 const Wishlist = ({ metaData }: MetaDataTypes) => {
   return (
@@ -22,15 +23,7 @@ export async function getServerSideProps(context: any) {
   const params = `?version=${version}&method=${method}&entity=${entity}`;
   const url = `${context.resolvedUrl.split('?')[0]}`;
   if (CONSTANTS.ENABLE_META_TAGS) {
-    let metaDataFromAPI: any = await MetaTag(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-    if (
-      metaDataFromAPI.status === 200 &&
-      metaDataFromAPI?.data?.message?.msg === 'success' &&
-      metaDataFromAPI?.data?.message?.data !== 'null'
-    ) {
-      const metaData = metaDataFromAPI?.data?.message?.data;
-      return { props: { metaData } };
-    }
+    return await getPageMetaData(params, url);
   } else {
     return {
       props: {},

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { CONSTANTS } from '../services/config/app-config';
 import MetaTag from '../services/api/general-apis/meta-tag-api';
-import { MetaDataTypes } from '../interfaces/meta-data-interface';
+import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import PageMetaData from '../components/PageMetaData';
 import WishlistMaster from '../components/WishlistComponents/WishListMaster';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 
-const Wishlist = ({ metaData }: MetaDataTypes) => {
+const Wishlist = ({ serverDataForPages }: ServerDataTypes) => {
   return (
     <>
-      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={metaData} />}
+      {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}
       <WishlistMaster />
     </>
   );

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { CONSTANTS } from '../services/config/app-config';
-import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import PageMetaData from '../components/PageMetaData';
 import WishlistMaster from '../components/WishlistComponents/WishListMaster';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 
 const Wishlist = ({ serverDataForPages }: ServerDataTypes) => {
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { CONSTANTS } from '../services/config/app-config';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
-import PageMetaData from '../components/PageMetaData';
-import WishlistMaster from '../components/WishlistComponents/WishListMaster';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import PageMetaData from '../components/PageMetaData';
+import WishlistMaster from '../components/WishlistComponents/WishListMaster';
 
 const Wishlist = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);

--- a/services/api/general-apis/multilanguage-api.ts
+++ b/services/api/general-apis/multilanguage-api.ts
@@ -26,7 +26,6 @@ const MultiLangApi = async (appConfig: APP_CONFIG) => {
                   `${CONSTANTS.API_BASE_URL}${CONSTANTS.SUMMIT_APP_CONFIG?.app_name}?version=${CONSTANTS.SUMMIT_APP_CONFIG.version}&method=${langTransmethod}&entity=${langTransentity}&language_code=${lang.language_code}`,
                   { timeout: 5000 }
                 );
-
                 return {
                   lang_name: lang.language_name,
                   lang_code: lang.language_code,
@@ -47,7 +46,6 @@ const MultiLangApi = async (appConfig: APP_CONFIG) => {
           )
         : [];
   }
-
   return generateMultiLingualArrayOfData;
 };
 

--- a/utils/fetch-page-meta-deta.ts
+++ b/utils/fetch-page-meta-deta.ts
@@ -1,21 +1,25 @@
 import MetaTagAPI from '../services/api/general-apis/meta-tag-api';
+import MultiLangApi from '../services/api/general-apis/multilanguage-api';
 import { CONSTANTS } from '../services/config/app-config';
 
 const getPageMetaData = async (params: string, url: string) => {
   const { SUMMIT_APP_CONFIG } = CONSTANTS;
-  let metaDataFromAPI: any = await MetaTagAPI(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
-  if (
-    metaDataFromAPI?.status === 200 &&
-    metaDataFromAPI?.data?.message?.msg === 'success' &&
-    metaDataFromAPI?.data?.message?.data !== 'null'
-  ) {
-    const metaData = metaDataFromAPI?.data?.message?.data;
-    return {
-      props: { metaData },
-    };
+  let serverDataForPages: any = {};
+  const MultilanguageData = await MultiLangApi(SUMMIT_APP_CONFIG);
+  if (MultilanguageData?.length > 0) {
+    serverDataForPages.multiLingualListTranslationTextList = MultilanguageData;
   } else {
-    return { props: {} };
+    serverDataForPages.multiLingualListTranslationTextList = [];
   }
+  let metaDataFromAPI: any = await MetaTagAPI(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
+  if (metaDataFromAPI?.status === 200 && metaDataFromAPI?.data?.message?.msg === 'success') {
+    serverDataForPages.metaData = metaDataFromAPI?.data?.message?.data;
+  } else {
+    serverDataForPages.metaData = {};
+  }
+  return {
+    props: { serverDataForPages },
+  };
 };
 
 export default getPageMetaData;

--- a/utils/fetch-page-meta-deta.ts
+++ b/utils/fetch-page-meta-deta.ts
@@ -1,0 +1,21 @@
+import MetaTagAPI from '../services/api/general-apis/meta-tag-api';
+import { CONSTANTS } from '../services/config/app-config';
+
+const getPageMetaData = async (params: string, url: string) => {
+  const { SUMMIT_APP_CONFIG } = CONSTANTS;
+  let metaDataFromAPI: any = await MetaTagAPI(`${CONSTANTS.API_BASE_URL}${SUMMIT_APP_CONFIG.app_name}${params}&page_name=${url}`);
+  if (
+    metaDataFromAPI?.status === 200 &&
+    metaDataFromAPI?.data?.message?.msg === 'success' &&
+    metaDataFromAPI?.data?.message?.data !== 'null'
+  ) {
+    const metaData = metaDataFromAPI?.data?.message?.data;
+    return {
+      props: { metaData },
+    };
+  } else {
+    return { props: {} };
+  }
+};
+
+export default getPageMetaData;


### PR DESCRIPTION
# Description

This PR introduces two major utilities to improve code reusability and modularity across pages:

1. Custom Hook: useInitializeStoreWithMultiLingualData
    - A React hook that checks if multi-language data exists in the Redux store.
    - If the store is empty, it initializes the store with the provided multi-language data and triggers the multi-language hook 
       (useMultilangHook).
2. Utility Function: getPageMetaData
    - Encapsulates the logic for fetching multi-language data and metadata for a page.
    - Returns a props object containing:
       - Multi-language data (multiLingualListTranslationTextList)
       - Page metadata (metaData) fetched via the API.

Fixes # (issue)

 This PR solves this issue
 
![image (7)](https://github.com/user-attachments/assets/a2eb010f-fa14-49d0-8064-b3073570e4aa)


