### PR TITLE
Add Utility Function to Initialize componentsList Slice Across All Pages

### DIFF
--- a/hooks/GeneralHooks/useInitializeStoreWithComponentsList.tsx
+++ b/hooks/GeneralHooks/useInitializeStoreWithComponentsList.tsx
@@ -1,0 +1,19 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { componentsListFromReduxStore, createComponentsList } from '../../store/slices/general_slices/components-slice';
+import { ComponentsTypes } from '../../interfaces/meta-data-interface';
+import { useEffect } from 'react';
+
+const useInitializeStoreWithComponentsList = (componentsListData: ComponentsTypes[]) => {
+  const dispatch = useDispatch();
+  const { componentsList }: any = useSelector(componentsListFromReduxStore);
+
+  useEffect(() => {
+    if (componentsList?.length !== 0) {
+      dispatch(createComponentsList(componentsListData));
+    }
+  }, []);
+
+  return {};
+};
+
+export default useInitializeStoreWithComponentsList;

--- a/hooks/GeneralHooks/useInitializeStoreWithComponentsList.tsx
+++ b/hooks/GeneralHooks/useInitializeStoreWithComponentsList.tsx
@@ -1,14 +1,14 @@
-import { useDispatch, useSelector } from 'react-redux';
-import { componentsListFromReduxStore, createComponentsList } from '../../store/slices/general_slices/components-slice';
-import { ComponentsTypes } from '../../interfaces/meta-data-interface';
 import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { ComponentsTypes } from '../../interfaces/meta-data-interface';
+import { componentsListFromReduxStore, createComponentsList } from '../../store/slices/general_slices/components-slice';
 
 const useInitializeStoreWithComponentsList = (componentsListData: ComponentsTypes[]) => {
   const dispatch = useDispatch();
   const { componentsList }: any = useSelector(componentsListFromReduxStore);
 
   useEffect(() => {
-    if (componentsList?.length !== 0) {
+    if (componentsList?.length === 0) {
       dispatch(createComponentsList(componentsListData));
     }
   }, []);

--- a/interfaces/components-types.ts
+++ b/interfaces/components-types.ts
@@ -1,0 +1,11 @@
+export interface ComponentTypes {
+  name: string; // The name of the page section
+  component: string; // The type of component used
+  page_name: string; // The name of the page (e.g., 'home-page')
+  section_name: string; // The section within the page (e.g., 'BannerSection')
+  image: string | null; // The image URL, which can be null if not provided
+}
+
+export interface ComponentsListTypes {
+  componentsList: ComponentTypes[]; // An array of `PageData` objects
+}

--- a/interfaces/meta-data-interface.ts
+++ b/interfaces/meta-data-interface.ts
@@ -1,3 +1,11 @@
+export interface ComponentsTypes {
+  name: string; // The name of the page section
+  component: string; // The type of component used
+  page_name: string; // The name of the page (e.g., 'home-page')
+  section_name: string; // The section within the page (e.g., 'BannerSection')
+  image: string | null; // The image URL, which can be null if not provided
+}
+
 export interface PageMetaDataTypes {
   page_name: string;
   meta_title: string;
@@ -7,6 +15,7 @@ export interface PageMetaDataTypes {
 interface PageData {
   metaData: PageMetaDataTypes;
   multiLingualListTranslationTextList: any[];
+  componentsList: ComponentsTypes[];
 }
 export interface ServerDataTypes {
   serverDataForPages: PageData;

--- a/pages/brand-product/[category-slug]/[productId]/index.tsx
+++ b/pages/brand-product/[category-slug]/[productId]/index.tsx
@@ -2,12 +2,13 @@ import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import useInitializeStoreWithMultiLingualData from '../../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
-import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
+import useInitializeStoreWithComponentsList from '../../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import PageMetaData from '../../../../components/PageMetaData';
+import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
-
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/brand/[category]/index.tsx
+++ b/pages/brand/[category]/index.tsx
@@ -1,12 +1,15 @@
+import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 import { CONSTANTS } from '../../../services/config/app-config';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
-import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithComponentsList from '../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import PageMetaData from '../../../components/PageMetaData';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
+
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
+import getPageMetaData from '../utils/fetch-page-meta-deta';
 import { CONSTANTS } from '../services/config/app-config';
 import CartListing from '../components/Cart/CartListing';
-import MetaTag from '../services/api/general-apis/meta-tag-api';
-import getPageMetaData from '../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
-
+import useInitializeStoreWithComponentsList from '../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 const Cart = ({ serverDataForPages }: any) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
-
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   return (
     <>
       <CartListing />

--- a/pages/catalog-product/[category]/[productId]/index.tsx
+++ b/pages/catalog-product/[category]/[productId]/index.tsx
@@ -2,11 +2,13 @@ import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import useInitializeStoreWithComponentsList from '../../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import PageMetaData from '../../../../components/PageMetaData';
 import ProductPageMaster from '../../../../components/ProductPageComponents/ProductPageMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/catalog/[category]/index.tsx
+++ b/pages/catalog/[category]/index.tsx
@@ -1,12 +1,15 @@
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 import { CONSTANTS } from '../../../services/config/app-config';
-import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../../../components/PageMetaData';
+import useInitializeStoreWithComponentsList from '../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
+import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
+
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/catalog/index.tsx
+++ b/pages/catalog/index.tsx
@@ -1,12 +1,14 @@
 import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import { CONSTANTS } from '../../services/config/app-config';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithComponentsList from '../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import useInitializeStoreWithMultiLingualData from '../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../../components/PageMetaData';
 import CatalogList from '../../components/Catalog/CatalogList';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
 
   return (
     <>

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,13 +1,14 @@
-import { CONSTANTS } from '../services/config/app-config';
-import MetaTag from '../services/api/general-apis/meta-tag-api';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
-import CheckoutPageMaster from '../components/CheckoutPageComponents/CheckoutPageMaster';
-import PageMetaData from '../components/PageMetaData';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import { CONSTANTS } from '../services/config/app-config';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import useInitializeStoreWithComponentsList from '../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
+import PageMetaData from '../components/PageMetaData';
+import CheckoutPageMaster from '../components/CheckoutPageComponents/CheckoutPageMaster';
 
 const Checkout = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages} />}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -4,12 +4,13 @@ import checkAuthorizedUser from '../utils/auth';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import useInitializeStoreWithComponentsList from '../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import PageMetaData from '../components/PageMetaData';
 import LoginComponent from '../components/Auth/LoginComponent';
 
 const login = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
-
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   const router = useRouter();
   function checkIfUserIsAuthorized() {
     const checkUserStatus = checkAuthorizedUser();

--- a/pages/product-category/[category]/index.tsx
+++ b/pages/product-category/[category]/index.tsx
@@ -1,15 +1,17 @@
 import { useEffect } from 'react';
-import { CONSTANTS } from '../../../services/config/app-config';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
+import { CONSTANTS } from '../../../services/config/app-config';
 import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import useGoogleAnalyticsOperationsHandler from '../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
+import useInitializeStoreWithComponentsList from '../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import PageMetaData from '../../../components/PageMetaData';
 import ProductListingMaster from '../../../components/ProductCategoriesComponents/ProductListingMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
-  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Listing Page');
   }, []);

--- a/pages/product-category/index.tsx
+++ b/pages/product-category/index.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from 'react';
-import { CONSTANTS } from '../../services/config/app-config';
 import { ServerDataTypes } from '../../interfaces/meta-data-interface';
 import getPageMetaData from '../../utils/fetch-page-meta-deta';
+import { CONSTANTS } from '../../services/config/app-config';
+import useInitializeStoreWithComponentsList from '../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import useGoogleAnalyticsOperationsHandler from '../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import useInitializeStoreWithMultiLingualData from '../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../../components/PageMetaData';
 import ProductListingMaster from '../../components/ProductCategoriesComponents/ProductListingMaster';
-
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
-  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
+  useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Listing Page');
   }, []);

--- a/pages/product/[category-slug]/[productId]/index.tsx
+++ b/pages/product/[category-slug]/[productId]/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { ServerDataTypes } from '../../../../interfaces/meta-data-interface';
 import { CONSTANTS } from '../../../../services/config/app-config';
 import getPageMetaData from '../../../../utils/fetch-page-meta-deta';
+import useInitializeStoreWithComponentsList from '../../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import useInitializeStoreWithMultiLingualData from '../../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import useGoogleAnalyticsOperationsHandler from '../../../../hooks/GoogleAnalytics/useGoogleAnalyticsOperationsHandler';
 import PageMetaData from '../../../../components/PageMetaData';
@@ -10,6 +11,7 @@ import ProductPageMaster from '../../../../components/ProductPageComponents/Prod
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   const { sendPageViewToGA } = useGoogleAnalyticsOperationsHandler();
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   useEffect(() => {
     sendPageViewToGA(window.location.pathname + window.location.search, 'Product Detail Page');
   }, []);

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,11 +1,13 @@
 import { CONSTANTS } from '../services/config/app-config';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
+import useInitializeStoreWithComponentsList from '../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../components/PageMetaData';
 
 const Register = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/reports/[order_report]/index.tsx
+++ b/pages/reports/[order_report]/index.tsx
@@ -1,12 +1,15 @@
-import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import getPageMetaData from '../../../utils/fetch-page-meta-deta';
 import { ServerDataTypes } from '../../../interfaces/meta-data-interface';
 import { CONSTANTS } from '../../../services/config/app-config';
+import useInitializeStoreWithComponentsList from '../../../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
+import useInitializeStoreWithMultiLingualData from '../../../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
 import PageMetaData from '../../../components/PageMetaData';
 import OrderReportMaster from '../../../components/OrderReportComponents/OrderReportMaster';
 
 const Index = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
+
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -2,11 +2,13 @@ import { CONSTANTS } from '../services/config/app-config';
 import { ServerDataTypes } from '../interfaces/meta-data-interface';
 import getPageMetaData from '../utils/fetch-page-meta-deta';
 import useInitializeStoreWithMultiLingualData from '../hooks/GeneralHooks/useInitializeStoreWithMultiLingualData';
+import useInitializeStoreWithComponentsList from '../hooks/GeneralHooks/useInitializeStoreWithComponentsList';
 import PageMetaData from '../components/PageMetaData';
 import WishlistMaster from '../components/WishlistComponents/WishListMaster';
 
 const Wishlist = ({ serverDataForPages }: ServerDataTypes) => {
   useInitializeStoreWithMultiLingualData(serverDataForPages?.multiLingualListTranslationTextList);
+  useInitializeStoreWithComponentsList(serverDataForPages?.componentsList);
   return (
     <>
       {CONSTANTS.ENABLE_META_TAGS && <PageMetaData meta_data={serverDataForPages.metaData} />}


### PR DESCRIPTION
Description:

- Created a utility function useInitializeComponentsList to check if the componentsList slice is empty. If it is, the function populates it with componentsListData.
- Applied this function to all relevant pages in the web app to ensure the componentsList slice is properly initialized and populated with the necessary data on page load.

Why?
 
 The significance of creating this hook file to populate store is to have componentsList available across all pages. If components added from backend is not available on pages then dynamically rendering them would become a problem.