### PR TITLE
fix: remove encodedURIComponent from password in get-token-from-login…

### DIFF
--- a/services/api/auth/get-token-from-login-api.ts
+++ b/services/api/auth/get-token-from-login-api.ts
@@ -25,7 +25,7 @@ const getTokenFromLoginAPI: any = async (appConfig: APP_CONFIG, loginParams: Typ
 
 export const emrLogin = async (loginParams: any) => {
   const usr = loginParams?.values.usr;
-  const pwd = encodeURIComponent(loginParams?.values?.pwd);
+  const pwd = loginParams?.values?.pwd;
   const body = {
     username: usr,
     password: pwd,


### PR DESCRIPTION
# Description

Removed encodedURIComponent from password in get-token-from-login-api to allow special characters in password without encoding.